### PR TITLE
fix chrome options args name

### DIFF
--- a/snapshot_selenium/snapshot.py
+++ b/snapshot_selenium/snapshot.py
@@ -55,7 +55,7 @@ def make_snapshot(
 def get_chrome_driver():
     options = webdriver.ChromeOptions()
     options.add_argument("headless")
-    return webdriver.Chrome(options=options)
+    return webdriver.Chrome(chrome_options=options)
 
 
 def get_safari_driver():


### PR DESCRIPTION
fix error: __init__() got an unexpected keyword argument 'options'
change arg from 'options' to 'chrome_options'